### PR TITLE
claude-in-sandbox: オンデマンドマウント・環境変数追加機能

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,21 @@ claude
 | `CC_SANDBOX_USER` | `claude` | コンテナ内のユーザー名 |
 | `CC_SANDBOX_DOTCLAUDE` | `~/.claude-in-sandbox/.claude` | ホスト側の `.claude` ディレクトリのパス（認証情報や設定が保存される） |
 | `CC_SANDBOX_DOTCONFIG` | `~/.claude-in-sandbox/.config` | ホスト側の `.config` ディレクトリのパス |
+| `CC_SANDBOX_M2_REPO` | `claude-code-m2-repo` | Maven ローカルリポジトリを保存する Docker ボリューム名 |
+| `CC_SANDBOX_M2_WRAPPER` | `claude-code-m2-wrapper` | Maven Wrapper のキャッシュを保存する Docker ボリューム名 |
+
+### 追加マウント・環境変数の指定
+
+起動時に `-v` / `-e` オプションで追加のマウントや環境変数をコンテナに渡せる。
+
+```bash
+claude-in-sandbox -v /path/to/host:/path/in/container -e MY_VAR=value
+```
+
+| オプション | 説明 |
+| --- | --- |
+| `--volume HOST:CT`, `-v HOST:CT` | ホストのパスをコンテナにマウントする。`HOST:CONTAINER` または `HOST:CONTAINER:ro` 形式。繰り返し指定可 |
+| `--env VAR=VALUE`, `-e VAR=VALUE` | コンテナに環境変数を設定する。`VAR=VALUE` または `VAR`（ホストから継承）形式。繰り返し指定可 |
 
 ### アクセス許可ドメインの変更
 

--- a/claude-in-sandbox
+++ b/claude-in-sandbox
@@ -24,6 +24,10 @@ Options:
   --cleanup         Stop and remove all Docker resources created by this script.
   --force, -f       Skip confirmation prompt when used with --cleanup.
   --list-mounts     Display all bind mounts and volumes used by the container.
+  --volume, -v HOST:CT   Mount a host path into the container (can be repeated).
+                         Format: HOST:CONTAINER or HOST:CONTAINER:ro
+  --env, -e VAR=VALUE    Set an environment variable in the container (can be repeated).
+                         Format: VAR=VALUE or VAR (inherits from host environment)
   --help, -h        Show this help message and exit.
 EOF
 }
@@ -152,11 +156,29 @@ list_mounts() {
     echo "  ${CC_SANDBOX_STATE_MISE_VOLUME} → ${remote_user_home}/.local/state/mise"
     echo "  ${CC_SANDBOX_M2_REPO} → ${remote_user_home}/.m2/repository"
     echo "  ${CC_SANDBOX_M2_WRAPPER} → ${remote_user_home}/.m2/wrapper"
+    if [[ ${#extra_volumes[@]} -gt 0 ]]; then
+        echo ""
+        echo "Additional mounts (--volume):"
+        local i
+        for (( i=1; i<${#extra_volumes[@]}; i+=2 )); do
+            echo "  ${extra_volumes[$i]}"
+        done
+    fi
+    if [[ ${#extra_envs[@]} -gt 0 ]]; then
+        echo ""
+        echo "Additional environment variables (--env):"
+        local i
+        for (( i=1; i<${#extra_envs[@]}; i+=2 )); do
+            echo "  ${extra_envs[$i]}"
+        done
+    fi
 }
 
 CLEANUP=false
 FORCE=false
 LIST_MOUNTS=false
+extra_volumes=()
+extra_envs=()
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
@@ -164,6 +186,24 @@ while [[ $# -gt 0 ]]; do
         --force|-f)    FORCE=true; shift ;;
         --list-mounts) LIST_MOUNTS=true; shift ;;
         --help|-h)     show_usage; exit 0 ;;
+        --volume|-v)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: $1 requires an argument." >&2
+                show_usage >&2
+                exit 1
+            fi
+            extra_volumes+=("-v" "$2")
+            shift 2
+            ;;
+        --env|-e)
+            if [[ $# -lt 2 ]]; then
+                echo "Error: $1 requires an argument." >&2
+                show_usage >&2
+                exit 1
+            fi
+            extra_envs+=("-e" "$2")
+            shift 2
+            ;;
         *) echo "Unknown option: $1" >&2; show_usage >&2; exit 1 ;;
     esac
 done
@@ -244,5 +284,7 @@ docker run -it --rm \
   -v "${script_dir}/proxy/maven/settings.xml:${remote_user_home}/.m2/settings.xml:ro" \
   -v "${CC_SANDBOX_M2_REPO}:${remote_user_home}/.m2/repository" \
   -v "${CC_SANDBOX_M2_WRAPPER}:${remote_user_home}/.m2/wrapper" \
+  ${extra_volumes[@]+"${extra_volumes[@]}"} \
+  ${extra_envs[@]+"${extra_envs[@]}"} \
   -w "$workspace" \
   "$CC_SANDBOX_IMAGE" bash


### PR DESCRIPTION
## Summary

- `-v` / `--volume` オプションを追加し、コンテナ起動時に追加のホストパスをマウントできるようにした
- `-e` / `--env` オプションを追加し、コンテナ起動時に追加の環境変数を渡せるようにした
- `--list-mounts` で追加指定のマウントと環境変数も表示するようにした

## 変更内容

| 変更箇所 | 内容 |
|---|---|
| `show_usage()` | `--volume` / `--env` のオプション説明を追加 |
| 引数処理ループ | `--volume\|-v` と `--env\|-e` のケースを追加。引数なし時はエラー終了 |
| `list_mounts()` | 追加マウント・環境変数の表示を追加 |
| `docker run` | `${arr[@]+"${arr[@]}"}` 形式で配列を安全に展開（bash 3.2 互換） |

## 使用例

```bash
# 追加マウントと環境変数を指定して起動
./claude-in-sandbox -v /host/data:/container/data -e MY_TOKEN=abc123

# read-only マウント
./claude-in-sandbox --volume /host/config:/etc/app/config:ro

# 複数指定
./claude-in-sandbox -v /a:/b -v /c:/d:ro -e FOO=bar -e BAZ

# 追加マウントを --list-mounts で確認（コンテナは起動しない）
./claude-in-sandbox -v /a:/b --list-mounts
```

## Test plan

- [x] `./claude-in-sandbox -v /tmp:/tmp/test` でマウントが反映されることを確認
- [x] `./claude-in-sandbox -e MY_VAR=hello` で環境変数が渡されることを確認
- [x] `./claude-in-sandbox -v /a:/b --list-mounts` で追加マウントが表示されることを確認
- [x] 引数なしで `-v` / `-e` を指定した場合にエラーメッセージが出ることを確認
- [x] 既存の `--cleanup` / `--force` / `--list-mounts` / `--help` の動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)